### PR TITLE
Create user in Intercom when event update fails

### DIFF
--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -33,14 +33,14 @@ function track(category, action, user, data) {
   // data, without a user ID, on logins)
   return intercom.events.create(event)
     .catch(err => {
+      logger.error('Error: no user found for ID ' + user.id);
       // FIXME use error object, this is an abomination
-      logger.error('caught');
       return updateUser(user)
         .then(() => {
-          logger.error('done');
+          logger.info('Created missing user', user);
           return track(category, action, user, data)
             .then(() => {
-              logger.error('donedone');
+              logger.info('Relogged event for user' + user.id);
             });
         });
     });


### PR DESCRIPTION
A quick fix to avoid annoying 409s in Emissary. The better fix will be to have Emissary make some kind of `boot` request to Myst, which will update the user, their last seen time, etc. Will do that on Monday. 
