### PR TITLE
Updated creation/sign-up timestamps in Intercom

### DIFF
--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -66,6 +66,13 @@ function updateUser(user) {
     update_last_request_at: true
   };
 
+  // Need to translate timestamps into UNIX timestamps (in seconds
+  if (user.created_at) {
+    const signedUpAt = _.floor(user.created_at / 1000);
+    update.signed_up_at = signedUpAt;
+    update.created_at = signedUpAt;
+  }
+
   // Don't include any attributes with null/undefined values or else
   // Intercom will overwrite existing data as blank.
   ['email', 'name', 'custom_attributes'].forEach(key => {


### PR DESCRIPTION
Noticed that new users weren't missing their "signed up" date in Intercom:

<img width="304" alt="screenshot 2016-07-06 18 05 11" src="https://cloud.githubusercontent.com/assets/855595/16636151/3e23ca0e-43a4-11e6-9946-5d6502e52071.png">

This fixes the 🐛. [Here is the Emissary PR.](https://github.com/opsee/emissary/pull/323)
