### PR TITLE
Fix info sent to intercom, including customer id

### DIFF
--- a/lib/intercom.js
+++ b/lib/intercom.js
@@ -61,23 +61,21 @@ function updateUser(user) {
     return Promise.resolve('Missing user.id parameter');
   }
 
-  const update = {
+  const signedUpAt = _.floor(user.created_at / 1000);
+  const update = _.chain({
     user_id: user.id,
-    update_last_request_at: true
-  };
-
-  // Need to translate timestamps into UNIX timestamps (in seconds
-  if (user.created_at) {
-    const signedUpAt = _.floor(user.created_at / 1000);
-    update.signed_up_at = signedUpAt;
-    update.created_at = signedUpAt;
-  }
-
+    update_last_request_at: true,
+    email: user.email,
+    signed_up_at: signedUpAt,
+    created_at: signedUpAt,
+    custom_attributes: _.assign({}, {
+      customer_id: user.customer_id
+    }, user.custom_attributes)
+  })
   // Don't include any attributes with null/undefined values or else
   // Intercom will overwrite existing data as blank.
-  ['email', 'name', 'custom_attributes'].forEach(key => {
-    if (key in user) update[key] = user[key];
-  });
+  .omitBy(_.isNil)
+  .value();
 
   logger.info('Updating Intercom user: ', JSON.stringify(update));
 


### PR DESCRIPTION
@coreylight sends customer ID to Myst and cleans up the intercom code a bit. FTR Emissary can post additional custom attributes to Myst/Intercom by sending a `custom_attributes` object as part of the user object it sends. (Using Intercom's `custom_attributes` stuff forces some Intercom-specific logic into Emissary, so maybe it'd be better to have Myst transform a user object into `custom_attributes` on its own like I did here for customer ID. Up 2 u!)
